### PR TITLE
Refactor UI for quiz output

### DIFF
--- a/index.live.html
+++ b/index.live.html
@@ -20,18 +20,10 @@
   <div id="root"></div>
   <script type="text/javascript">
     window.vars = {
-      htmlReport: {{json htmlReport}},
-      charts: {{json charts}},
-      metadata: {{json metadata}},
-      sources: {{json rawResearch}},
+      quiz: {{json quiz}},
+      output: {{json output}},
+      timestamps: {{json timestamps}}
     };
-
-    window.vars.podcastUrl = {{json podcastUrl}};
-    window.vars.podcastTitle = {{json podcastTitle}};
-    window.vars.podcastDescription = {{json podcastDescription}};
-    window.vars.podcastEpisodeTitle = {{json podcastEpisodeTitle}};
-    window.vars.podcastEpisodeDescription = {{json podcastEpisodeDescription}};
-    window.vars.podcastCoverImage = {{json podcastCoverImage}};
   </script>
 </body>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,10 @@
-import { useMemo } from 'react';
 import styled from 'styled-components';
-import Header from './components/Header';
-import Report from './components/Report';
-import TableOfContents from './components/TableOfContents';
-import Intro from './components/Intro';
-import Sources, { Source } from './components/Sources';
-import MetadataRibbon from './components/MetadataRibbon';
-import Footer from './components/Footer';
-import Podcast from './components/Podcast';
-import { preprocessHtml } from './helpers/processHtml';
 import { AnimatePresence, motion } from 'framer-motion';
+import Header from './components/Header';
+import Footer from './components/Footer';
+import Quiz, { QuizItem } from './components/Quiz';
+import SessionSummary from './components/SessionSummary';
+import VideoTimestamps, { Timestamp } from './components/VideoTimestamps';
 import { colors } from './style/theme';
 
 const Container = styled(motion.div)`
@@ -30,119 +25,21 @@ const Container = styled(motion.div)`
 
 const Content = styled.div`
   width: 100%;
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
-  gap: 72px;
-
-  @media (max-width: 700px) {
-    padding: 20px;
-    flex-direction: column;
-    justify-content: flex-start;
-  }
-
-  @media print {
-    flex-direction: column;
-    justify-content: flex-start;
-    align-items: center;
-  }
-`;
-
-const TocPane = styled.div`
-  width: 300px;
-  max-width: 300px;
-  min-width: 300px;
-
-  position: sticky;
-  top: 32px;
-  display: flex;
-  align-self: flex-start;
-  max-height: calc(100svh - 32px); /* visible viewport area */
-  overflow: hidden; /* hide overflow from outer container */
-
-  @media (max-width: 700px) {
-    width: 100%;
-    max-width: 100%;
-    min-width: 100%;
-    top: unset;
-    position: relative;
-    max-height: unset;
-  }
-
-  @media print {
-    display: none;
-  }
-`;
-
-const ReportPane = styled.div`
-  width: 100%;
   max-width: 720px;
-
-  @media (max-width: 700px) {
-    max-width: 100%;
-  }
+  margin: 0 auto;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
 `;
 
 function App() {
   const unsafeWindow: any = window;
-  const {
-    metadata,
-    htmlReport,
-    charts,
-    sources,
-
-    podcastUrl,
-    podcastCoverImage,
-    podcastTitle,
-    podcastDescription,
-    podcastEpisodeTitle,
-    podcastEpisodeDescription,
-  }: {
-    htmlReport: string;
-    charts: any;
-    metadata: {
-      categoryName: string;
-      dateCreated: string;
-      title: string;
-      description: string;
-      summary: string[];
-    };
-    sources: Source[];
-    podcastUrl?: string;
-    podcastCoverImage?: string;
-    podcastTitle: string;
-    podcastDescription: string;
-    podcastEpisodeTitle: string;
-    podcastEpisodeDescription: string;
+  const { quiz, output, timestamps }: {
+    quiz: QuizItem[];
+    output: string;
+    timestamps: Timestamp[];
   } = unsafeWindow?.vars ?? {};
-
-  const { html, toc } = useMemo(
-    () => preprocessHtml(htmlReport, charts, sources),
-    [htmlReport, charts, sources],
-  );
-
-  let resolvedToc = toc;
-  if (podcastUrl) {
-    resolvedToc = [
-      {
-        id: 'podcast',
-        text: 'Podcast',
-      },
-      ...toc,
-    ];
-  }
-
-  resolvedToc = [
-    {
-      id: 'takeaway',
-      text: 'The Takeaway',
-    },
-    ...resolvedToc,
-    {
-      id: 'sources',
-      text: 'Sources',
-    },
-  ];
 
   return (
     <AnimatePresence>
@@ -152,46 +49,15 @@ function App() {
           exit={{ opacity: 0 }}
           transition={{ duration: 0.5, delay: 0.3 }}
         >
-          <a id="top" />
-          {/* The Header no longer takes a title */}
-          <Header />
-
-          {/* The Intro now takes the title and description */}
-          <Intro
-            title={metadata.title}
-            description={metadata.description}
-            summary={metadata.summary}
-          />
-
-          <Content>
-            <TocPane>
-              <TableOfContents toc={resolvedToc} title={metadata.title} />
-            </TocPane>
-            <ReportPane>
-              <MetadataRibbon
-                dateCreated={metadata.dateCreated}
-                html={htmlReport}
-              />
-              {podcastUrl && podcastCoverImage && (
-                <Podcast
-                  audioUrl={podcastUrl}
-                  imageUrl={podcastCoverImage}
-                  metadata={{
-                    podcastTitle,
-                    podcastDescription,
-                    episodeTitle: podcastEpisodeTitle,
-                    episodeDescription: podcastEpisodeDescription
-                  }}
-                />
-              )}
-              <Report html={html} charts={charts} />
-            </ReportPane>
-          </Content>
-
-          <Sources sources={sources} />
-          <Footer />
-        </Container>
-    </AnimatePresence>
+            <Header />
+            <Content>
+              <Quiz quiz={quiz} />
+              <SessionSummary output={output} />
+              <VideoTimestamps timestamps={timestamps} />
+            </Content>
+            <Footer />
+          </Container>
+      </AnimatePresence>
   );
 }
 

--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -1,0 +1,41 @@
+import styled from 'styled-components';
+import { colors } from '../style/theme';
+
+export interface QuizItem {
+  question: string;
+  answer: string;
+}
+
+const Container = styled.div`
+  width: 100%;
+  max-width: 720px;
+  margin: 32px auto;
+  text-align: left;
+`;
+
+const Question = styled.div`
+  font-weight: bold;
+  margin-bottom: 4px;
+`;
+
+const Answer = styled.div`
+  margin-bottom: 12px;
+  color: ${colors.content.secondary};
+`;
+
+const Quiz = ({ quiz }: { quiz: QuizItem[] }) => {
+  if (!quiz || quiz.length === 0) return null;
+  return (
+    <Container>
+      <h2>Quiz</h2>
+      {quiz.map((item, idx) => (
+        <div key={idx}>
+          <Question>{item.question}</Question>
+          <Answer>{item.answer}</Answer>
+        </div>
+      ))}
+    </Container>
+  );
+};
+
+export default Quiz;

--- a/src/components/SessionSummary.tsx
+++ b/src/components/SessionSummary.tsx
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+import { colors } from '../style/theme';
+
+const Container = styled.div`
+  width: 100%;
+  max-width: 720px;
+  margin: 32px auto;
+  text-align: left;
+`;
+
+const Text = styled.p`
+  white-space: pre-wrap;
+  color: ${colors.content.primary};
+`;
+
+const SessionSummary = ({ output }: { output: string }) => {
+  if (!output) return null;
+  return (
+    <Container>
+      <h2>Session Summary</h2>
+      <Text>{output}</Text>
+    </Container>
+  );
+};
+
+export default SessionSummary;

--- a/src/components/VideoTimestamps.tsx
+++ b/src/components/VideoTimestamps.tsx
@@ -1,0 +1,44 @@
+import styled from 'styled-components';
+import { colors } from '../style/theme';
+
+export interface Timestamp {
+  time: string;
+  note: string;
+}
+
+const Container = styled.div`
+  width: 100%;
+  max-width: 720px;
+  margin: 32px auto;
+  text-align: left;
+`;
+
+const Row = styled.div`
+  margin-bottom: 8px;
+`;
+
+const Time = styled.span`
+  font-weight: bold;
+  margin-right: 8px;
+`;
+
+const Note = styled.span`
+  color: ${colors.content.secondary};
+`;
+
+const VideoTimestamps = ({ timestamps }: { timestamps: Timestamp[] }) => {
+  if (!timestamps || timestamps.length === 0) return null;
+  return (
+    <Container>
+      <h2>Video Timestamps</h2>
+      {timestamps.map((ts, idx) => (
+        <Row key={idx}>
+          <Time>{ts.time}</Time>
+          <Note>{ts.note}</Note>
+        </Row>
+      ))}
+    </Container>
+  );
+};
+
+export default VideoTimestamps;


### PR DESCRIPTION
## Summary
- simplify data injection with quiz/output/timestamps
- drop old report components
- add Quiz, SessionSummary and VideoTimestamps
- rework `App.tsx` to display the new data

## Testing
- `npm run build` *(fails: Cannot find module)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_686e77438370832da2a0d1762847cc2f